### PR TITLE
Added abilty to customize php extensions on a per job basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,14 @@ We provide docker gitlab-ci runner images for php 5.3, 5.4, 5.5 and 5.6 containi
 - PHP 5.x
 - Git
 - Composer
-- Xdebug
+
+These images also comes with the following extensions pre-installed but not enabled by default with the exception of
+`xdebug`:
+
+- memcache
+- mongo.so
+- redis.so
+- xdebug.so
 
 ### Usage
 
@@ -80,6 +87,17 @@ php vendor/phpunit/phpunit/phpunit --coverage-text
 By displaying code coverage as text, you can easily extract code coverage metrics. In your project settings, under
 "Test coverage parsing", just input the following regex: `  Lines:\s+(\d+.\d+\%)`.
 
+### Custom PHP configuration
+
+If you need to customize the php configuration, you can add your own settings to the `ci-runner.ini` file.
+For example, `bobey/docker-gitlab-ci-runner-php5.5` comes with pre-installed mongo.so extension but yet need to be
+loaded if you need it.
+
+The following command in your gitlab-ci job will do the trick:
+
+```
+echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/ci-runner.ini
+```
 
 ### Development
 

--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update -y && \
     apt-get install -y git \
                        wget \
                        curl \
-                       apache2
+                       apache2 \
+                       php-pear
 
 # Install a specific bison version
 RUN wget -O /tmp/libbison-dev.deb http://launchpadlibrarian.net/140087283/libbison-dev_2.7.1.dfsg-1_amd64.deb && \
@@ -41,5 +42,12 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/libfreetype.so && \
     ln -s /usr/lib/x86_64-linux-gnu/libldap.so     /usr/lib/libldap.so && \
     ln -s /usr/include/x86_64-linux-gnu/gmp.h      /usr/include/gmp.h
 
+# Install PHP PECL extensions
+RUN yes '' | pecl install \
+	mongo \
+	redis \
+	memcache
+
+# Install composer
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
PHP images now provide pre-installed following extensions:
- memcache
- mongo.so
- redis.so
- xdebug.so

Extensions enabling on a per-job basis is now documented in README.
