### PR TITLE
Added xdebug to PECL extensions

### DIFF
--- a/php/5.4/Dockerfile
+++ b/php/5.4/Dockerfile
@@ -16,4 +16,5 @@ RUN yes '' | pecl install \
 	mongo \
 	redis \
 	memcache \
-	ssh2-0.12
+	ssh2-0.12 \
+	xdebug

--- a/php/5.5/Dockerfile
+++ b/php/5.5/Dockerfile
@@ -16,4 +16,5 @@ RUN yes '' | pecl install \
 	mongo \
 	redis \
 	memcache \
-	ssh2-0.12
+	ssh2-0.12 \
+	xdebug

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -16,4 +16,5 @@ RUN yes '' | pecl install \
 	mongo \
 	redis \
 	memcache \
-	ssh2-0.12
+	ssh2-0.12 \
+	xdebug


### PR DESCRIPTION
In PHP 5.4/5.5/5.6, added xdebug setup to add last xdebug version. xdebug 2.3.1 has a bug while used with phpunit code coverage.
